### PR TITLE
feat: setitem buff

### DIFF
--- a/e2e/test_artist_simple_setting.py
+++ b/e2e/test_artist_simple_setting.py
@@ -4,6 +4,7 @@ from loasim.job import SkillState
 
 state = {
     "저무는 달": BuffState(onoff=False),
+    "내면의 각성": BuffState(onoff=True),
     "나만의 권능": BuffState(onoff=True),
     "나만의 우물": BuffState(onoff=True),
 }

--- a/e2e/test_hawkeye_simple_setting.py
+++ b/e2e/test_hawkeye_simple_setting.py
@@ -5,6 +5,7 @@ from loasim.job import SkillState
 
 state = {
     "피해 증폭": BuffState(onoff=True),
+    "내면의 각성": BuffState(onoff=True),
 }
 
 deal_cycle: DealCycle = [

--- a/e2e/test_scouter_simple_setting.py
+++ b/e2e/test_scouter_simple_setting.py
@@ -3,11 +3,33 @@ from loasim.core import Enemy, InternalStat, Stat
 from loasim.core.buff import BuffState
 from loasim.job.base import SkillState
 
-sync_state = {
+sync0_state = {
+    "환각": BuffState(onoff=False),
+    "실체": BuffState(onoff=True),
+    "진화의 유산": BuffState(onoff=True, stack=0),
+    "하이퍼 싱크": BuffState(onoff=True),
+}
+sync1_state = {
+    "환각": BuffState(onoff=False),
+    "실체": BuffState(onoff=True),
+    "진화의 유산": BuffState(onoff=True, stack=1),
+    "하이퍼 싱크": BuffState(onoff=True),
+}
+sync2_state = {
+    "환각": BuffState(onoff=False),
+    "실체": BuffState(onoff=True),
+    "진화의 유산": BuffState(onoff=True, stack=2),
+    "하이퍼 싱크": BuffState(onoff=True),
+}
+sync3_state = {
+    "환각": BuffState(onoff=False),
+    "실체": BuffState(onoff=True),
     "진화의 유산": BuffState(onoff=True, stack=3),
     "하이퍼 싱크": BuffState(onoff=True),
 }
 nosync_state = {
+    "환각": BuffState(onoff=False),
+    "실체": BuffState(onoff=True),
     "진화의 유산": BuffState(onoff=False),
     "하이퍼 싱크": BuffState(onoff=False),
 }
@@ -15,27 +37,27 @@ nosync_state = {
 deal_cycle: DealCycle = [  # 레미-베드-QESQRWAQEWQRWSQEWAQRW 23s
     ("명령 : 레이드 미사일", nosync_state, None),
     ("명령 : 베이비 드론", nosync_state, None),
-    ("코멧 스트라이크", sync_state, None),
-    ("레이저 블레이드", sync_state, None),
-    ("크림슨 브레이커", sync_state, None),
-    ("코멧 스트라이크", sync_state, None),
-    ("엑셀리온 빔", sync_state, None),
-    ("슬러그 샷", sync_state, None),
-    ("버스트 블로우", sync_state, None),
-    ("코멧 스트라이크", sync_state, None),
-    ("레이저 블레이드", sync_state, None),
-    ("슬러그 샷", sync_state, None),
-    ("코멧 스트라이크", sync_state, None),
-    ("엑셀리온 빔", sync_state, None),
-    ("슬러그 샷", sync_state, None),
-    ("크림슨 브레이커", sync_state, None),
-    ("코멧 스트라이크", sync_state, None),
-    ("레이저 블레이드", sync_state, None),
-    ("슬러그 샷", sync_state, None),
-    ("버스트 블로우", sync_state, None),
-    ("코멧 스트라이크", sync_state, None),
-    ("엑셀리온 빔", sync_state, None),
-    ("슬러그 샷", sync_state, None),
+    ("코멧 스트라이크", sync0_state, None),
+    ("레이저 블레이드", sync1_state, None),
+    ("크림슨 브레이커", sync2_state, None),
+    ("코멧 스트라이크", sync3_state, None),
+    ("엑셀리온 빔", sync3_state, None),
+    ("슬러그 샷", sync3_state, None),
+    ("버스트 블로우", sync3_state, None),
+    ("코멧 스트라이크", sync3_state, None),
+    ("레이저 블레이드", sync3_state, None),
+    ("슬러그 샷", sync3_state, None),
+    ("코멧 스트라이크", sync3_state, None),
+    ("엑셀리온 빔", sync3_state, None),
+    ("슬러그 샷", sync3_state, None),
+    ("크림슨 브레이커", sync3_state, None),
+    ("코멧 스트라이크", sync3_state, None),
+    ("레이저 블레이드", sync3_state, None),
+    ("슬러그 샷", sync3_state, None),
+    ("버스트 블로우", sync3_state, None),
+    ("코멧 스트라이크", sync3_state, None),
+    ("엑셀리온 빔", sync3_state, None),
+    ("슬러그 샷", sync3_state, None),
 ]
 
 calculate(

--- a/loasim/calculate.py
+++ b/loasim/calculate.py
@@ -23,12 +23,14 @@ def calculate(
     enemy: Enemy,
     deal_cycle: DealCycle,
     cycle_time: float,
+    additional_stat: Stat = Stat(),
 ):
     base_stat = internal_stat.get_stat()
     weapon_stat = Stat(pdamage=weapon_pdamage)  # 무기 품질
     basis_stat = (
         base_stat
         + weapon_stat
+        + additional_stat
         + lostark_setitem_repository.get_stat(setitem_state)
         + lostark_default_card_repository.get_stat(card_state)
     )
@@ -39,7 +41,8 @@ def calculate(
     job = get_job(job_name)
     skills, buffs = job.build(skill_state, internal_stat)
     engraving_buffs = lostark_engraving_repository.get_buffs(engraving_state)
-    buff_manager = BuffManager(engraving_buffs + buffs)
+    setitem_buffs = lostark_setitem_repository.get_buffs(setitem_state)
+    buff_manager = BuffManager(engraving_buffs + setitem_buffs + buffs)
 
     total_damage = 0.0
     damage_dict: defaultdict[str, float] = defaultdict(float)

--- a/loasim/core/buff.py
+++ b/loasim/core/buff.py
@@ -135,13 +135,13 @@ class InternalStatOnoffBuff(AbstractBuff):
 
 class BuffManager:
     def __init__(self, buff_list: List[AbstractBuff]) -> None:
-        self._buffs: Dict[str, AbstractBuff] = {}
-        self._stat_buffs: Dict[str, StatBuff] = {}
+        self._buffs: List[AbstractBuff] = []
+        self._stat_buffs: List[StatBuff] = []
         for buff in buff_list:
             if isinstance(buff, StatBuff):
-                self._stat_buffs[buff.name] = buff
+                self._stat_buffs.append(buff)
             else:
-                self._buffs[buff.name] = buff
+                self._buffs.append(buff)
 
     def get_stat(
         self,
@@ -151,10 +151,10 @@ class BuffManager:
         internal_stat: InternalStat,
     ) -> Stat:
         stat = Stat()
-        for buff in self._buffs.values():
-            stat = stat + buff.get_stat(state, skill, stat, internal_stat)
+        for buff in self._buffs:
+            stat = stat + buff.get_stat(state, skill, basis_stat, internal_stat)
 
-        for buff in self._stat_buffs.values():
+        for buff in self._stat_buffs:
             stat = stat + buff.get_stat(state, skill, stat + basis_stat, internal_stat)
 
         return stat

--- a/loasim/core/skill.py
+++ b/loasim/core/skill.py
@@ -19,6 +19,7 @@ class Skill(BaseModel):
     type: SkillType
     head: bool
     back: bool
+    consume_mana: bool
     stat: Stat
     skill_afters: List[Skill]
 

--- a/loasim/job/base.py
+++ b/loasim/job/base.py
@@ -47,6 +47,7 @@ class SkillSpecification(BaseModel):
     type: SkillType
     head: bool = False
     back: bool = False
+    consume_mana: bool = True
     tripods: List[Tripod] = []
     skill_afters: List[str] = []
     stat_from_special: Optional[Callable[[float], Stat]] = None
@@ -121,6 +122,7 @@ class Job:
             type=skill_type,
             head=skill.head,
             back=skill.back,
+            consume_mana=skill.consume_mana,
             stat=stat,
             skill_afters=skill_afters,
         )

--- a/loasim/job/blade.py
+++ b/loasim/job/blade.py
@@ -463,6 +463,7 @@ lostark_job_blade.add_skill(
     SkillSpecification(
         name="블레이드 버스트",
         type="Normal",
+        consume_mana=False,
         damage_table={
             11: (7244, 42.873),
         },

--- a/loasim/job/scouter.py
+++ b/loasim/job/scouter.py
@@ -19,6 +19,7 @@ lostark_job_scouter.add_skill(
     SkillSpecification(
         name="명령 : 레이드 미사일",
         type="Normal",
+        consume_mana=False,
         damage_table={
             12: (3066, 19.10),
         },
@@ -51,6 +52,7 @@ lostark_job_scouter.add_skill(
     SkillSpecification(
         name="명령 : 베이비 드론",
         type="Area",
+        consume_mana=False,
         damage_table={
             12: (3200, 19.71),
         },
@@ -83,6 +85,7 @@ lostark_job_scouter.add_skill(
     SkillSpecification(
         name="코멧 스트라이크",
         type="Area",
+        consume_mana=False,
         damage_table={
             12: (1809, 11.27),
         },
@@ -92,6 +95,7 @@ lostark_job_scouter.add_skill(
     SkillSpecification(
         name="슬러그 샷",
         type="Area",
+        consume_mana=False,
         damage_table={
             12: (1841, 11.50),
         },
@@ -101,6 +105,7 @@ lostark_job_scouter.add_skill(
     SkillSpecification(
         name="레이저 블레이드",
         type="Area",
+        consume_mana=False,
         damage_table={
             12: (3707, 23.13),
         },
@@ -110,6 +115,7 @@ lostark_job_scouter.add_skill(
     SkillSpecification(
         name="엑셀리온 빔",
         type="Area",
+        consume_mana=False,
         damage_table={
             12: (4603, 28.70),
         },
@@ -120,6 +126,7 @@ lostark_job_scouter.add_skill(
     SkillSpecification(
         name="버스트 블로우",
         type="Area",
+        consume_mana=False,
         damage_table={
             12: (3488, 21.71),
         },
@@ -129,6 +136,7 @@ lostark_job_scouter.add_skill(
     SkillSpecification(
         name="크림슨 브레이커",
         type="Area",
+        consume_mana=False,
         damage_table={
             12: (7200, 44.94),
         },

--- a/loasim/setitem/base.py
+++ b/loasim/setitem/base.py
@@ -1,21 +1,39 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from pydantic import BaseModel
 
-from loasim.core import Stat
+from loasim.core.buff import AbstractBuff
+from loasim.core.stat import Stat
 
 
 class SetItem(BaseModel):
     name: str
-    stat_list: List[Tuple[Stat, Stat]]
+    stat_list: List[Optional[Tuple[Stat, Stat]]]
+    buff_list: List[Optional[Tuple[AbstractBuff, AbstractBuff]]]
 
-    def get_stat(self, level1_set: int, level2_set: int):
+    def get_stat(self, level1_set: int, level2_set: int) -> Stat:
         stat = Stat()
         for i in range(level2_set // 2):
-            stat = stat + self.stat_list[i][1]
+            stat_tuple = self.stat_list[i]
+            if stat_tuple is not None:
+                stat = stat + stat_tuple[1]
         for i in range(level2_set // 2, level1_set // 2):
-            stat = stat + self.stat_list[i][0]
+            stat_tuple = self.stat_list[i]
+            if stat_tuple is not None:
+                stat = stat + stat_tuple[0]
         return stat
+
+    def get_buffs(self, level1_set: int, level2_set: int) -> List[AbstractBuff]:
+        buffs: List[AbstractBuff] = []
+        for i in range(level2_set // 2):
+            buff_tuple = self.buff_list[i]
+            if buff_tuple is not None:
+                buffs.append(buff_tuple[1])
+        for i in range(level2_set // 2, level1_set // 2):
+            buff_tuple = self.buff_list[i]
+            if buff_tuple is not None:
+                buffs.append(buff_tuple[0])
+        return buffs
 
 
 class SetItemRepository:
@@ -31,3 +49,12 @@ class SetItemRepository:
             stat = stat + self._set_items[name].get_stat(level1, level2)
 
         return stat
+
+    def get_buffs(
+        self, setitem_state: List[Tuple[str, int, int]]
+    ) -> List[AbstractBuff]:
+        buffs: List[AbstractBuff] = []
+        for name, level1, level2 in setitem_state:
+            buffs += self._set_items[name].get_buffs(level1, level2)
+
+        return buffs

--- a/loasim/setitem/builtin.py
+++ b/loasim/setitem/builtin.py
@@ -1,4 +1,4 @@
-from loasim.core import Stat
+from loasim.core import OnoffBuff, SkillBuff, StackBuff, Stat
 from loasim.core.stat import sub_pdamage_indep
 from loasim.setitem.base import SetItem, SetItemRepository
 
@@ -9,9 +9,23 @@ lostark_setitem_repository.add(
     SetItem(
         name="환각",
         stat_list=[
-            (Stat(), Stat()),  #  2환각 미지원
-            (Stat(crit=15), Stat(crit=18)),
-            (Stat(pdamage_indep=25, crit=5), Stat(pdamage_indep=29, crit=7)),
+            None,
+            (
+                Stat(crit=15),
+                Stat(crit=18),
+            ),
+            None,
+        ],
+        buff_list=[
+            (
+                OnoffBuff(name="환각", stat=Stat(pdamage_indep=13)),
+                OnoffBuff(name="환각", stat=Stat(pdamage_indep=15)),
+            ),
+            None,
+            (
+                OnoffBuff(name="실체", stat=Stat(pdamage_indep=25, crit=5)),
+                OnoffBuff(name="실체", stat=Stat(pdamage_indep=29, crit=7)),
+            ),
         ],
     )
 )
@@ -20,9 +34,41 @@ lostark_setitem_repository.add(
     SetItem(
         name="악몽",
         stat_list=[
-            (Stat(pdamage_indep=12), Stat(pdamage_indep=15)),
-            (Stat(pdamage=15), Stat(pdamage=18)),
-            (Stat(pdamage_indep=15), Stat(pdamage_indep=18)),
+            None,
+            None,
+            None,
+        ],
+        buff_list=[
+            (
+                SkillBuff(
+                    name="악몽",
+                    stat_fn=lambda skill: Stat(pdamage_indep=skill.consume_mana * 12),
+                ),
+                SkillBuff(
+                    name="악몽",
+                    stat_fn=lambda skill: Stat(pdamage_indep=skill.consume_mana * 15),
+                ),
+            ),
+            (
+                OnoffBuff(
+                    name="마나 중독",
+                    stat=Stat(pdamage=15),
+                ),
+                OnoffBuff(
+                    name="마나 중독",
+                    stat=Stat(pdamage=18),
+                ),
+            ),
+            (
+                OnoffBuff(
+                    name="마나 중독",
+                    stat=Stat(pdamage_indep=15),
+                ),
+                OnoffBuff(
+                    name="마나 중독",
+                    stat=Stat(pdamage_indep=18),
+                ),
+            ),
         ],
     ),
 )
@@ -31,12 +77,41 @@ lostark_setitem_repository.add(
     SetItem(
         name="지배",
         stat_list=[
-            (Stat(pdamage_indep=10), Stat(pdamage_indep=10)),
+            None,
+            None,
+            None,
+        ],
+        buff_list=[
             (
-                Stat(pdamage_indep=25) - Stat(pdamage_indep=10),
-                Stat(pdamage_indep=28) - Stat(pdamage_indep=10),
+                OnoffBuff(
+                    name="내면의 각성",
+                    stat=Stat(pdamage_indep=10),
+                ),
+                OnoffBuff(
+                    name="내면의 각성",
+                    stat=Stat(pdamage_indep=10),
+                ),
             ),
-            (Stat(pdamage_indep=15), Stat(pdamage_indep=18)),
+            (
+                OnoffBuff(
+                    name="내면의 각성",
+                    stat=Stat(pdamage_indep=25) - Stat(pdamage_indep=10),
+                ),
+                OnoffBuff(
+                    name="내면의 각성",
+                    stat=Stat(pdamage_indep=28) - Stat(pdamage_indep=10),
+                ),
+            ),
+            (
+                OnoffBuff(
+                    name="내면의 각성",
+                    stat=Stat(pdamage_indep=15),
+                ),
+                OnoffBuff(
+                    name="내면의 각성",
+                    stat=Stat(pdamage_indep=18),
+                ),
+            ),
         ],
     )
 )
@@ -45,11 +120,44 @@ lostark_setitem_repository.add(
     SetItem(
         name="구원",
         stat_list=[
-            (Stat(pdamage=14), Stat(pdamage=18)),
-            (Stat(pdamage=14), Stat(pdamage=18)),
+            None,
+            None,
+            None,
+        ],
+        buff_list=[
             (
-                Stat(pdamage=14, pdamage_indep=5),
-                Stat(pdamage=18, pdamage_indep=5),
+                StackBuff(
+                    name="고양",
+                    stat_fn=lambda stack: Stat(pdamage=min(stack, 20) * 0.7),
+                ),
+                StackBuff(
+                    name="고양",
+                    stat_fn=lambda stack: Stat(pdamage=min(stack, 20) * 0.9),
+                ),
+            ),
+            (
+                StackBuff(
+                    name="고양",
+                    stat_fn=lambda stack: Stat(pdamage=min(stack, 20) * 0.7),
+                ),
+                StackBuff(
+                    name="고양",
+                    stat_fn=lambda stack: Stat(pdamage=min(stack, 20) * 0.9),
+                ),
+            ),
+            (
+                StackBuff(
+                    name="고양",
+                    stat_fn=lambda stack: Stat(
+                        pdamage=min(stack, 20) * 0.7, pdamage_indep=(stack == 20) * 5
+                    ),
+                ),
+                StackBuff(
+                    name="고양",
+                    stat_fn=lambda stack: Stat(
+                        pdamage=min(stack, 20) * 0.9, pdamage_indep=(stack == 20) * 5
+                    ),
+                ),
             ),
         ],
     ),
@@ -63,7 +171,10 @@ lostark_setitem_repository.add(
                 Stat(crit_damage=17, crit_damage_back=55 - 17),
                 Stat(crit_damage=20, crit_damage_back=60 - 20),
             ),
-            (Stat(crit=17), Stat(crit=20)),
+            (
+                Stat(crit=17),
+                Stat(crit=20),
+            ),
             (
                 Stat(
                     pdamage_indep=7,
@@ -75,5 +186,6 @@ lostark_setitem_repository.add(
                 ),
             ),
         ],
+        buff_list=[None, None, None],
     ),
 )

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -14,6 +14,7 @@ def test_skill():
         multiplier=1,
         head=False,
         back=False,
+        consume_mana=True,
         stat=Stat(),
         skill_afters=[],
     )

--- a/tests/engraving/conftest.py
+++ b/tests/engraving/conftest.py
@@ -14,6 +14,7 @@ def test_skill():
         multiplier=1,
         head=False,
         back=False,
+        consume_mana=True,
         stat=Stat(),
         skill_afters=[],
     )

--- a/tests/setitem/test_setitem.py
+++ b/tests/setitem/test_setitem.py
@@ -4,13 +4,20 @@ from loasim.setitem import lostark_setitem_repository
 
 
 @pytest.mark.parametrize(
-    "setitem_name, setitem_lv1, setitem_lv2",
+    "setitem_name",
+    ["환각", "악몽", "지배", "구원", "사멸"],
+)
+@pytest.mark.parametrize(
+    "setitem_lv1, setitem_lv2",
     [
-        ("환각", 2, 2),
-        ("악몽", 3, 4),
-        ("지배", 0, 6),
-        ("구원", 6, 0),
+        (2, 0),
+        (4, 0),
+        (6, 0),
+        (6, 2),
+        (6, 4),
+        (6, 6),
     ],
 )
 def test_setitem_repository(setitem_name: str, setitem_lv1: int, setitem_lv2: int):
     lostark_setitem_repository.get_stat([(setitem_name, setitem_lv1, setitem_lv2)])
+    lostark_setitem_repository.get_buffs([(setitem_name, setitem_lv1, setitem_lv2)])


### PR DESCRIPTION
### `Setitem`이 `Buff`를 가져야 하는 이유

* 악몽 2세트의 "마나를 사용하는 스킬의 피해 증가"를 `SkillBuff`로 적용해야 함
  * 대신 `Stat`에 `pdamage_indep_mana`와 같은 필드를 추가하는 것도 가능은 함
* 악몽 4세트, 6세트는 "마나 중독"과 "끝없는 마나" 두개의 버프를 가지므로 하나로만 적용할 수 없음
  * 세트를 악몽(마나 중독) / 악몽(끝없는 마나) 로 분리하는 것도 가능은 함

### 정리해야 할 부분

* 구원 세트의 경우 `StackBuff`긴 하지만, 항상 최대 스택을 가정하고 `Stat`으로 써도 될까?
* 지배 세트의 경우 `OnoffBuff`긴 하지만, 항상 켜진 것으로 가정하고 `Stat`으로 써도 될까?
  * 불필요한 BuffState가 추가되는 게 싫다
* 구원 세트와 같이 세트 수에 따라 버프 효과가 누적되는 경우 어떻게 처리할지?
  * `Stat`은 더하면서 누적하는게 가능한데, `Buff`는 어려움
  * `OnoffBuff`간에는 덧셈 연산을 정의할 수 있어도, `StackBuff`는 어려움
  * 이전 세트 효과를 덮어쓰는 방식으로 하면 (2세트 2레벨, 4세트 1레벨)과 같은 경우를 표현할 수 없음